### PR TITLE
test: ignore ConfigureWritable() on coverage

### DIFF
--- a/src/Nogic.WritableOptions/ServiceCollectionExtension.cs
+++ b/src/Nogic.WritableOptions/ServiceCollectionExtension.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -19,6 +20,7 @@ namespace Nogic.WritableOptions
         /// <param name="services">The <see cref="IServiceCollection"/> to add the services to.</param>
         /// <param name="section">The configuration being bound.</param>
         /// <param name="file">Setting JSON file name. (should be placed in content-root folder or current folder)</param>
+        [ExcludeFromCodeCoverage]
         public static void ConfigureWritable<TOptions>(
             this IServiceCollection services,
             IConfigurationSection section,


### PR DESCRIPTION
[`ServiceCollectionExtension.ConfigureWritable()`](https://github.com/nogic1008/WritableOptions.Net/blob/main/src/Nogic.WritableOptions/ServiceCollectionExtension.cs) uses "extension method" and "lambda", so it is difficult to make unit test.

This PR causes them to be ignored on coverage.

*Note: If We find a good way to test, this change will be reverted.*