### PR TITLE
style: move `using` directive to top

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -91,6 +91,7 @@ csharp_prefer_braces = when_multiline:warning
 csharp_prefer_simple_using_statement = true:warning
 
 csharp_using_directive_placement = outside_namespace
+csharp_style_namespace_declarations = file_scoped
 
 csharp_prefer_static_local_function = true:warning
 

--- a/sandbox/Benchmark/BenchmarkConfig.cs
+++ b/sandbox/Benchmark/BenchmarkConfig.cs
@@ -1,8 +1,8 @@
-namespace Benchmark;
-
 using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Environments;
 using BenchmarkDotNet.Jobs;
+
+namespace Benchmark;
 
 public class BenchmarkConfig : ManualConfig
 {

--- a/sandbox/Benchmark/WritableOptionsBenchmark.cs
+++ b/sandbox/Benchmark/WritableOptionsBenchmark.cs
@@ -1,8 +1,7 @@
 #nullable disable
-namespace Benchmark;
-
-using System.IO;
 using BenchmarkDotNet.Attributes;
+
+namespace Benchmark;
 
 [Config(typeof(BenchmarkConfig))]
 public class WritableOptionsBenchmark

--- a/src/Nogic.WritableOptions/IWritableOptions.cs
+++ b/src/Nogic.WritableOptions/IWritableOptions.cs
@@ -1,6 +1,6 @@
-namespace Nogic.WritableOptions;
-
 using Microsoft.Extensions.Options;
+
+namespace Nogic.WritableOptions;
 
 /// <summary>
 /// Used to access or update the value of <typeparamref name="TOptions"/>.

--- a/src/Nogic.WritableOptions/JsonWritableOptions.cs
+++ b/src/Nogic.WritableOptions/JsonWritableOptions.cs
@@ -1,11 +1,10 @@
-namespace Nogic.WritableOptions;
-
-using System.IO;
 using System.Text;
 using System.Text.Encodings.Web;
 using System.Text.Json;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Options;
+
+namespace Nogic.WritableOptions;
 
 /// <summary>
 /// Read and write <typeparamref name="TOptions"/> in JSON file.

--- a/src/Nogic.WritableOptions/ServiceCollectionExtension.cs
+++ b/src/Nogic.WritableOptions/ServiceCollectionExtension.cs
@@ -1,10 +1,9 @@
-namespace Nogic.WritableOptions;
-
-using System.IO;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
+
+namespace Nogic.WritableOptions;
 
 /// <summary>
 /// Extension methods for adding configuration related writable options services to the DI container.

--- a/test/Nogic.WritableOptions.Tests/JsonWritableOptions.Test.cs
+++ b/test/Nogic.WritableOptions.Tests/JsonWritableOptions.Test.cs
@@ -1,10 +1,10 @@
-namespace Nogic.WritableOptions.Tests;
-
 using System.IO;
 using System.Text;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Options;
 using Moq;
+
+namespace Nogic.WritableOptions.Tests;
 
 /// <summary>
 /// Unit Test Class for <see cref="JsonWritableOptions{TOptions}"/>.

--- a/test/Nogic.WritableOptions.Tests/JsonWritableOptions.Test.cs
+++ b/test/Nogic.WritableOptions.Tests/JsonWritableOptions.Test.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using System.Text;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Options;

--- a/test/Nogic.WritableOptions.Tests/ServiceCollectionExtension.Test.cs
+++ b/test/Nogic.WritableOptions.Tests/ServiceCollectionExtension.Test.cs
@@ -1,7 +1,7 @@
-namespace Nogic.WritableOptions.Tests;
-
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+
+namespace Nogic.WritableOptions.Tests;
 
 /// <summary>
 /// Unit Test Class for <see cref="ServiceCollectionExtension"/>.


### PR DESCRIPTION
- declare to use file-scoped namespace on `.editorconfig` (to dismiss [IDE0160](https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/formatting-rules#namespace-options))
- move `using` directive to top (to fix [IDE0065](https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0065))
- remove unused `using` directive (to fix CS8019)