### PR TITLE
style: discard expression value

### DIFF
--- a/sandbox/Benchmark/BenchmarkConfig.cs
+++ b/sandbox/Benchmark/BenchmarkConfig.cs
@@ -7,10 +7,8 @@ namespace Benchmark;
 public class BenchmarkConfig : ManualConfig
 {
     public BenchmarkConfig()
-    {
-        AddJob(Job.Default.WithRuntime(CoreRuntime.Core31))
+        => AddJob(Job.Default.WithRuntime(CoreRuntime.Core31))
+            .WithOptions(ConfigOptions.DisableOptimizationsValidator)
+            .AddJob(Job.Default.WithRuntime(CoreRuntime.Core60))
             .WithOptions(ConfigOptions.DisableOptimizationsValidator);
-        AddJob(Job.Default.WithRuntime(CoreRuntime.Core60))
-            .WithOptions(ConfigOptions.DisableOptimizationsValidator);
-    }
 }

--- a/src/Nogic.WritableOptions/ServiceCollectionExtension.cs
+++ b/src/Nogic.WritableOptions/ServiceCollectionExtension.cs
@@ -21,17 +21,15 @@ public static class ServiceCollectionExtension
         this IServiceCollection services,
         IConfigurationSection section,
         string file = "appsettings.json") where TOptions : class, new()
-    {
-        services.Configure<TOptions>(section);
-        services.AddTransient<IWritableOptions<TOptions>>(provider =>
-        {
-            var environment = provider.GetService<IHostEnvironment>();
-            string jsonFilePath = environment?.ContentRootFileProvider.GetFileInfo(file).PhysicalPath
-                ?? Path.Combine(AppDomain.CurrentDomain.BaseDirectory, file);
+        => services.Configure<TOptions>(section)
+            .AddTransient<IWritableOptions<TOptions>>(provider =>
+            {
+                var environment = provider.GetService<IHostEnvironment>();
+                string jsonFilePath = environment?.ContentRootFileProvider.GetFileInfo(file).PhysicalPath
+                    ?? Path.Combine(AppDomain.CurrentDomain.BaseDirectory, file);
 
-            var configuration = provider.GetService<IConfigurationRoot>();
-            var options = provider.GetRequiredService<IOptionsMonitor<TOptions>>();
-            return new JsonWritableOptions<TOptions>(jsonFilePath, section.Key, options, configuration);
-        });
-    }
+                var configuration = provider.GetService<IConfigurationRoot>();
+                var options = provider.GetRequiredService<IOptionsMonitor<TOptions>>();
+                return new JsonWritableOptions<TOptions>(jsonFilePath, section.Key, options, configuration);
+            });
 }

--- a/test/Nogic.WritableOptions.Tests/JsonWritableOptions.Test.cs
+++ b/test/Nogic.WritableOptions.Tests/JsonWritableOptions.Test.cs
@@ -30,12 +30,12 @@ public sealed class JsonWritableOptionsTest
         // Arrange
         var sampleOption = GenerateOption();
         var optionsMock = new Mock<IOptionsMonitor<SampleOption>>();
-        optionsMock.SetupGet(m => m.CurrentValue).Returns(sampleOption);
+        _ = optionsMock.SetupGet(m => m.CurrentValue).Returns(sampleOption);
 
         var sut = new JsonWritableOptions<SampleOption>(null!, null!, optionsMock.Object, null);
 
         // Act - Assert
-        sut.Value.Should().Be(sampleOption);
+        _ = sut.Value.Should().Be(sampleOption);
         optionsMock.VerifyGet(m => m.CurrentValue, Times.Once());
     }
 
@@ -48,13 +48,13 @@ public sealed class JsonWritableOptionsTest
         // Arrange
         var sampleOption = GenerateOption();
         var optionsMock = new Mock<IOptionsMonitor<SampleOption>>();
-        optionsMock.Setup(m => m.Get(It.IsAny<string>())).Returns(sampleOption);
+        _ = optionsMock.Setup(m => m.Get(It.IsAny<string>())).Returns(sampleOption);
 
         var sut = new JsonWritableOptions<SampleOption>(null!, null!, optionsMock.Object, null);
 
         // Act - Assert
-        sut.Get("Foo").Should().Be(sampleOption);
-        sut.Get("Bar").Should().Be(sampleOption);
+        _ = sut.Get("Foo").Should().Be(sampleOption);
+        _ = sut.Get("Bar").Should().Be(sampleOption);
 
         optionsMock.Verify(m => m.Get(It.IsAny<string>()), Times.Exactly(2));
         optionsMock.Verify(m => m.Get("Foo"), Times.Once());
@@ -89,7 +89,7 @@ public sealed class JsonWritableOptionsTest
 
         // Assert
         string newLine = Environment.NewLine;
-        tempFile.ReadAllText().Should().Be("{" + newLine
+        _ = tempFile.ReadAllText().Should().Be("{" + newLine
             + "  \"" + nameof(SampleOption) + "\": {" + newLine
             + "    \"LastLaunchedAt\": \"2020-12-01T00:00:00\"," + newLine
             + "    \"Interval\": 5000," + newLine
@@ -128,7 +128,7 @@ public sealed class JsonWritableOptionsTest
 
         // Assert
         string newLine = Environment.NewLine;
-        tempFile.ReadAllText(Encoding.UTF8).Should().Be("{" + newLine
+        _ = tempFile.ReadAllText(Encoding.UTF8).Should().Be("{" + newLine
             + "  \"" + nameof(SampleOption) + "\": {" + newLine
             + "    \"LastLaunchedAt\": \"2020-12-01T00:00:00\"," + newLine
             + "    \"Interval\": 5000," + newLine
@@ -165,7 +165,7 @@ public sealed class JsonWritableOptionsTest
 
         // Assert
         string newLine = Environment.NewLine;
-        tempFile.ReadAllText().Should().Contain("\"fooOption\": {},");
+        _ = tempFile.ReadAllText().Should().Contain("\"fooOption\": {},");
     }
 
     /// <summary>
@@ -192,7 +192,7 @@ public sealed class JsonWritableOptionsTest
 
         // Assert
         string newLine = Environment.NewLine;
-        tempFile.ReadAllText().Should().Be("{" + newLine
+        _ = tempFile.ReadAllText().Should().Be("{" + newLine
             + "  \"" + nameof(SampleOption) + "\": {" + newLine
             + "    \"LastLaunchedAt\": \"2020-12-01T00:00:00\"," + newLine
             + "    \"Interval\": 5000," + newLine

--- a/test/Nogic.WritableOptions.Tests/ServiceCollectionExtension.Test.cs
+++ b/test/Nogic.WritableOptions.Tests/ServiceCollectionExtension.Test.cs
@@ -22,7 +22,7 @@ public sealed class ServiceCollectionExtensionTest
         var option = provider.GetService<IWritableOptions<SampleOption>>();
         var otherOption = provider.GetService<IWritableOptions<SampleOption>>();
 
-        option.Should().NotBeNull()
+        _ = option.Should().NotBeNull()
             .And.BeOfType<JsonWritableOptions<SampleOption>>()
             .And.NotBe(otherOption);
     }


### PR DESCRIPTION
To fix [IDE0058](https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0058): "Remove unnecessary expression value"
- use expression-body method
- discard expression value