### PR TITLE
build: add NoWarn option on test projects

### DIFF
--- a/sandbox/Benchmark/Benchmark.csproj
+++ b/sandbox/Benchmark/Benchmark.csproj
@@ -4,6 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net6.0;netcoreapp3.1</TargetFrameworks>
     <IsPackable>false</IsPackable>
+    <NoWarn>CA1707</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Nogic.WritableOptions.Tests/Nogic.WritableOptions.Tests.csproj
+++ b/test/Nogic.WritableOptions.Tests/Nogic.WritableOptions.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
+    <NoWarn>CA1707</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
@@ -21,8 +22,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Using Include="FluentAssertions"/>
-    <Using Include="Xunit"/>
+    <Using Include="FluentAssertions" />
+    <Using Include="Xunit" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
To dismiss [CA1707](https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1707) warnings