### PR TITLE
refactor: store UTF-8 encoded text instead of `string`

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -40,11 +40,14 @@ jobs:
 
       - name: Add Job Summaries
         run: |
-          "# Benchmark Result:bar_chart:" >> $env:GITHUB_STEP_SUMMARY
+          "# Benchmark Result:bar_chart: from ${{ github.sha }}" >> $env:GITHUB_STEP_SUMMARY
           cat ./sandbox/Benchmark/BenchmarkDotNet.Artifacts/results/Benchmark.WritableOptionsBenchmark-report-github.md >> $env:GITHUB_STEP_SUMMARY
           "## Legends" >> $GITHUB_STEP_SUMMARY
           "- **Mean**: Arithmetic mean of all measurements" >> $env:GITHUB_STEP_SUMMARY
           "- **Error**: Half of 99.9% confidence interval" >> $env:GITHUB_STEP_SUMMARY
           "- **StdDev**: Standard deviation of all measurements" >> $env:GITHUB_STEP_SUMMARY
           "- **Ratio**: Mean of the ratio distribution ([Current]/[Baseline])" >> $env:GITHUB_STEP_SUMMARY
+          "- **RatioSD**: Standard deviation of the ratio distribution ([Current]/[Baseline])" >> $env:GITHUB_STEP_SUMMARY
+          "- **Gen 0**: GC Generation 0 collects per 1000 operations" >> $env:GITHUB_STEP_SUMMARY
+          "- **Allocated**: Allocated memory per single operation (managed only, inclusive, 1KB = 1024B)" >> $env:GITHUB_STEP_SUMMARY
           "- **1 ms**: 1 Millisecond (0.001 sec)" >> $env:GITHUB_STEP_SUMMARY

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -31,7 +31,7 @@ jobs:
         run: dotnet restore --locked-mode
       - name: Run Benchmark
         working-directory: sandbox/Benchmark
-        run: dotnet run -c Release -f net6.0 --filter *WritableOptionsBenchmark*
+        run: dotnet run -c Release -f net6.0
 
       - uses: actions/upload-artifact@v3.0.0
         with:

--- a/sandbox/Benchmark/Benchmark.csproj
+++ b/sandbox/Benchmark/Benchmark.csproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Awesome.Net.WritableOptions" Version="3.0.0" />
     <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
+    <PackageReference Include="Moq" Version="4.18.0" />
     <PackageReference Include="Nogic.WritableOptions" Version="1.1.1" Aliases="release" />
   </ItemGroup>
 

--- a/sandbox/Benchmark/BenchmarkConfig.cs
+++ b/sandbox/Benchmark/BenchmarkConfig.cs
@@ -1,4 +1,5 @@
 using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Diagnosers;
 using BenchmarkDotNet.Environments;
 using BenchmarkDotNet.Jobs;
 
@@ -12,5 +13,6 @@ public class BenchmarkConfig : ManualConfig
             .AddJob(Job.Default.WithRuntime(CoreRuntime.Core60))
             .WithOptions(ConfigOptions.DisableOptimizationsValidator)
             .AddJob(Job.Default.WithRuntime(ClrRuntime.Net48))
-            .WithOptions(ConfigOptions.DisableOptimizationsValidator);
+            .WithOptions(ConfigOptions.DisableOptimizationsValidator)
+            .AddDiagnoser(MemoryDiagnoser.Default);
 }

--- a/sandbox/Benchmark/Program.cs
+++ b/sandbox/Benchmark/Program.cs
@@ -1,6 +1,4 @@
 using Benchmark;
 using BenchmarkDotNet.Running;
 
-BenchmarkSwitcher
-    .FromAssemblies(new[] { typeof(WritableOptionsBenchmark).Assembly })
-    .Run(args);
+BenchmarkRunner.Run<WritableOptionsBenchmark>();

--- a/sandbox/Benchmark/README.md
+++ b/sandbox/Benchmark/README.md
@@ -5,7 +5,7 @@ Compare this project with [Awesome.Net.WritableOptions](https://www.nuget.org/pa
 ## How To
 
 ```console
-> dotnet run -c Release -f net6.0 --filter *WritableOptionsBenchmark*
+> dotnet run -c Release -f net6.0
 ```
 
 ## Test Code
@@ -14,7 +14,7 @@ Compare this project with [Awesome.Net.WritableOptions](https://www.nuget.org/pa
 
 ```cs
 // Awesome.Net.WritableOptions<T>
-for (int i = 0; i < 1000; i++)
+for (int i = 0; i < 100; i++)
 {
     _awesomeWritableOptions.Update(o =>
     {
@@ -25,7 +25,7 @@ for (int i = 0; i < 1000; i++)
 }
 
 // Nogic.WritableOptions<T>
-for (int i = 0; i < 1000; i++)
+for (int i = 0; i < 100; i++)
 {
     _myWritableOptions.Update(_option);
 }

--- a/sandbox/Benchmark/WritableOptionsBenchmark.cs
+++ b/sandbox/Benchmark/WritableOptionsBenchmark.cs
@@ -2,6 +2,8 @@
 extern alias dev;
 extern alias release;
 using BenchmarkDotNet.Attributes;
+using Microsoft.Extensions.Options;
+using Moq;
 using AwesomeNet = Awesome.Net.WritableOptions;
 using Dev = dev::Nogic.WritableOptions;
 using Release = release::Nogic.WritableOptions;
@@ -20,6 +22,7 @@ public class WritableOptionsBenchmark
 
     private const int UpdateLoopCount = 100;
 
+    private IOptionsMonitor<SampleOption> _options;
     private AwesomeNet.WritableOptions<SampleOption> _awesomeWritableOptions;
     private Release.JsonWritableOptions<SampleOption> _releaseWritableOptions;
     private Dev.JsonWritableOptions<SampleOption> _devWritableOptions;
@@ -39,9 +42,10 @@ public class WritableOptionsBenchmark
     {
         _jsonFilePath = Path.GetTempFileName();
         File.AppendAllText(_jsonFilePath, "{}");
-        _awesomeWritableOptions = new(_jsonFilePath, nameof(SampleOption), null!, null);
-        _releaseWritableOptions = new(_jsonFilePath, nameof(SampleOption), null!, null);
-        _devWritableOptions = new(_jsonFilePath, nameof(SampleOption), null!, null);
+        _options = new Mock<IOptionsMonitor<SampleOption>>().Object;
+        _awesomeWritableOptions = new(_jsonFilePath, nameof(SampleOption), _options, null);
+        _releaseWritableOptions = new(_jsonFilePath, nameof(SampleOption), _options, null);
+        _devWritableOptions = new(_jsonFilePath, nameof(SampleOption), _options, null);
     }
 
     [Benchmark(Description = $"{nameof(Awesome)}.{nameof(Awesome.Net)}.{nameof(Awesome.Net.WritableOptions)}")]

--- a/sandbox/Benchmark/WritableOptionsBenchmark.cs
+++ b/sandbox/Benchmark/WritableOptionsBenchmark.cs
@@ -18,6 +18,8 @@ public class WritableOptionsBenchmark
         public int[] IntSettings { get; set; }
     }
 
+    private const int UpdateLoopCount = 100;
+
     private AwesomeNet.WritableOptions<SampleOption> _awesomeWritableOptions;
     private Release.JsonWritableOptions<SampleOption> _releaseWritableOptions;
     private Dev.JsonWritableOptions<SampleOption> _devWritableOptions;
@@ -42,10 +44,10 @@ public class WritableOptionsBenchmark
         _devWritableOptions = new(_jsonFilePath, nameof(SampleOption), null!, null);
     }
 
-    [Benchmark]
+    [Benchmark(Description = $"{nameof(Awesome)}.{nameof(Awesome.Net)}.{nameof(Awesome.Net.WritableOptions)}")]
     public void AwesomeWritableOptions_Update()
     {
-        for (int i = 0; i < 1000; i++)
+        for (int i = 0; i < UpdateLoopCount; i++)
         {
             _awesomeWritableOptions.Update(o =>
             {
@@ -56,17 +58,17 @@ public class WritableOptionsBenchmark
         }
     }
 
-    [Benchmark(Baseline = true)]
+    [Benchmark(Baseline = true, Description = $"(NuGet){nameof(release.Nogic)}.{nameof(release.Nogic.WritableOptions)}")]
     public void ReleaseWritableOptions_Update()
     {
-        for (int i = 0; i < 1000; i++)
+        for (int i = 0; i < UpdateLoopCount; i++)
             _releaseWritableOptions.Update(_option);
     }
 
-    [Benchmark]
+    [Benchmark(Description = $"(Dev){nameof(dev.Nogic)}.{nameof(dev.Nogic.WritableOptions)}")]
     public void DevWritableOptions_Update()
     {
-        for (int i = 0; i < 1000; i++)
+        for (int i = 0; i < UpdateLoopCount; i++)
             _devWritableOptions.Update(_option);
     }
 

--- a/src/Nogic.WritableOptions/JsonWritableOptions.cs
+++ b/src/Nogic.WritableOptions/JsonWritableOptions.cs
@@ -14,7 +14,7 @@ public class JsonWritableOptions<TOptions> : IWritableOptions<TOptions> where TO
 {
     private readonly IOptionsMonitor<TOptions> _options;
     private readonly string _jsonFilePath;
-    private readonly ReadOnlyMemory<byte> _sectionUtf8Bytes;
+    private readonly JsonEncodedText _section;
     private readonly IConfigurationRoot? _configuration;
 
     /// <summary>
@@ -25,7 +25,7 @@ public class JsonWritableOptions<TOptions> : IWritableOptions<TOptions> where TO
     /// <param name="options">Instance to read <typeparamref name="TOptions"/>. Should be referenced <paramref name="jsonFilePath"/>.</param>
     /// <param name="configuration">Configuration root for reload</param>
     public JsonWritableOptions(string jsonFilePath, string section, IOptionsMonitor<TOptions> options, IConfigurationRoot? configuration = null)
-        => (_jsonFilePath, _sectionUtf8Bytes, _options, _configuration) = (jsonFilePath, Encoding.UTF8.GetBytes(section), options, configuration);
+        => (_jsonFilePath, _section, _options, _configuration) = (jsonFilePath, JsonEncodedText.Encode(section), options, configuration);
 
     /// <inheritdoc/>
     public TOptions Value => _options.CurrentValue;
@@ -82,18 +82,18 @@ public class JsonWritableOptions<TOptions> : IWritableOptions<TOptions> where TO
             var optionsElement = JsonDocument.Parse(JsonSerializer.SerializeToUtf8Bytes(changedValue));
             foreach (var element in jsonDocument.RootElement.EnumerateObject())
             {
-                if (!element.NameEquals(_sectionUtf8Bytes.Span))
+                if (!element.NameEquals(_section.EncodedUtf8Bytes))
                 {
                     element.WriteTo(writer);
                     continue;
                 }
-                writer.WritePropertyName(_sectionUtf8Bytes.Span);
+                writer.WritePropertyName(_section);
                 optionsElement.WriteTo(writer);
                 isWritten = true;
             }
             if (!isWritten)
             {
-                writer.WritePropertyName(_sectionUtf8Bytes.Span);
+                writer.WritePropertyName(_section);
                 optionsElement.WriteTo(writer);
             }
             writer.WriteEndObject();

--- a/src/Nogic.WritableOptions/JsonWritableOptions.cs
+++ b/src/Nogic.WritableOptions/JsonWritableOptions.cs
@@ -24,8 +24,34 @@ public class JsonWritableOptions<TOptions> : IWritableOptions<TOptions> where TO
     /// <param name="section">JSON property name to store settings.</param>
     /// <param name="options">Instance to read <typeparamref name="TOptions"/>. Should be referenced <paramref name="jsonFilePath"/>.</param>
     /// <param name="configuration">Configuration root for reload</param>
+    /// <exception cref="ArgumentNullException">
+    /// Throws if <paramref name="jsonFilePath"/>, <paramref name="section"/> or <paramref name="options"/> is <see langword="null"/>.
+    /// </exception>
     public JsonWritableOptions(string jsonFilePath, string section, IOptionsMonitor<TOptions> options, IConfigurationRoot? configuration = null)
-        => (_jsonFilePath, _section, _options, _configuration) = (jsonFilePath, JsonEncodedText.Encode(section), options, configuration);
+    {
+#if NET6_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(jsonFilePath);
+        ArgumentNullException.ThrowIfNull(section);
+        ArgumentNullException.ThrowIfNull(options);
+#else
+        ThrowIfNull(jsonFilePath, nameof(jsonFilePath));
+        ThrowIfNull(section, nameof(section));
+        ThrowIfNull(options, nameof(options));
+#endif
+
+        _jsonFilePath = jsonFilePath;
+        _section = JsonEncodedText.Encode(section);
+        _options = options;
+        _configuration = configuration;
+#if !NET6_0_OR_GREATER
+        // Port of ArgumentNullException.ThrowIfNull
+        static void ThrowIfNull(object? argument, string paramName)
+        {
+            if (argument is null)
+                throw new ArgumentNullException(paramName);
+        }
+#endif
+    }
 
     /// <inheritdoc/>
     public TOptions Value => _options.CurrentValue;

--- a/src/Nogic.WritableOptions/JsonWritableOptions.cs
+++ b/src/Nogic.WritableOptions/JsonWritableOptions.cs
@@ -14,7 +14,7 @@ public class JsonWritableOptions<TOptions> : IWritableOptions<TOptions> where TO
 {
     private readonly IOptionsMonitor<TOptions> _options;
     private readonly string _jsonFilePath;
-    private readonly byte[] _sectionUtf8Bytes;
+    private readonly ReadOnlyMemory<byte> _sectionUtf8Bytes;
     private readonly IConfigurationRoot? _configuration;
 
     /// <summary>
@@ -82,18 +82,18 @@ public class JsonWritableOptions<TOptions> : IWritableOptions<TOptions> where TO
             var optionsElement = JsonDocument.Parse(JsonSerializer.SerializeToUtf8Bytes(changedValue));
             foreach (var element in jsonDocument.RootElement.EnumerateObject())
             {
-                if (!element.NameEquals(_sectionUtf8Bytes))
+                if (!element.NameEquals(_sectionUtf8Bytes.Span))
                 {
                     element.WriteTo(writer);
                     continue;
                 }
-                writer.WritePropertyName(_sectionUtf8Bytes);
+                writer.WritePropertyName(_sectionUtf8Bytes.Span);
                 optionsElement.WriteTo(writer);
                 isWritten = true;
             }
             if (!isWritten)
             {
-                writer.WritePropertyName(_sectionUtf8Bytes);
+                writer.WritePropertyName(_sectionUtf8Bytes.Span);
                 optionsElement.WriteTo(writer);
             }
             writer.WriteEndObject();

--- a/test/Nogic.WritableOptions.Tests/JsonWritableOptions.Test.cs
+++ b/test/Nogic.WritableOptions.Tests/JsonWritableOptions.Test.cs
@@ -32,7 +32,7 @@ public sealed class JsonWritableOptionsTest
         var optionsMock = new Mock<IOptionsMonitor<SampleOption>>();
         _ = optionsMock.SetupGet(m => m.CurrentValue).Returns(sampleOption);
 
-        var sut = new JsonWritableOptions<SampleOption>(null!, null!, optionsMock.Object, null);
+        var sut = new JsonWritableOptions<SampleOption>(null!, "", optionsMock.Object, null);
 
         // Act - Assert
         _ = sut.Value.Should().Be(sampleOption);
@@ -50,7 +50,7 @@ public sealed class JsonWritableOptionsTest
         var optionsMock = new Mock<IOptionsMonitor<SampleOption>>();
         _ = optionsMock.SetupGet(m => m.CurrentValue).Returns(sampleOption);
 
-        var sut = new JsonWritableOptions<SampleOption>(null!, null!, optionsMock.Object, null);
+        var sut = new JsonWritableOptions<SampleOption>(null!, "", optionsMock.Object, null);
 
         // Act - Assert
         _ = sut.CurrentValue.Should().Be(sampleOption);
@@ -68,7 +68,7 @@ public sealed class JsonWritableOptionsTest
         var optionsMock = new Mock<IOptionsMonitor<SampleOption>>();
         _ = optionsMock.Setup(m => m.Get(It.IsAny<string>())).Returns(sampleOption);
 
-        var sut = new JsonWritableOptions<SampleOption>(null!, null!, optionsMock.Object, null);
+        var sut = new JsonWritableOptions<SampleOption>(null!, "", optionsMock.Object, null);
 
         // Act - Assert
         _ = sut.Get("Foo").Should().Be(sampleOption);
@@ -91,7 +91,7 @@ public sealed class JsonWritableOptionsTest
         var action = (SampleOption option, string section)
             => Console.WriteLine($"{nameof(SampleOption)}:{section} changed to {option}");
 
-        var sut = new JsonWritableOptions<SampleOption>(null!, null!, optionsMock.Object, null);
+        var sut = new JsonWritableOptions<SampleOption>(null!, "", optionsMock.Object, null);
 
         // Act
         _ = sut.OnChange(action);

--- a/test/Nogic.WritableOptions.Tests/JsonWritableOptions.Test.cs
+++ b/test/Nogic.WritableOptions.Tests/JsonWritableOptions.Test.cs
@@ -21,6 +21,13 @@ public sealed class JsonWritableOptionsTest
         ConnectionString = new Guid().ToString()
     };
 
+    /// <summary>
+    /// Constractor throws <see cref="ArgumentNullException"/>
+    /// </summary>
+    /// <param name="jsonFilePath"><inheritdoc cref="JsonWritableOptions{TOptions}.JsonWritableOptions" path="/param[@name='jsonFilePath']" /></param>
+    /// <param name="section"><inheritdoc cref="JsonWritableOptions{TOptions}.JsonWritableOptions" path="/param[@name='section']" /></param>
+    /// <param name="hasOptions">set options as <see langword="null"/> or not</param>
+    /// <param name="paramName">Expected <see cref="ArgumentNullException"/> param name</param>
     [Theory]
     [InlineData(null, "", true, "jsonFilePath")]
     [InlineData("", null, true, "section")]

--- a/test/Nogic.WritableOptions.Tests/JsonWritableOptions.Test.cs
+++ b/test/Nogic.WritableOptions.Tests/JsonWritableOptions.Test.cs
@@ -21,6 +21,20 @@ public sealed class JsonWritableOptionsTest
         ConnectionString = new Guid().ToString()
     };
 
+    [Theory]
+    [InlineData(null, "", true, "jsonFilePath")]
+    [InlineData("", null, true, "section")]
+    [InlineData("", "", false, "options")]
+    public void Constractor_Throws_ArgumentNullException(string? jsonFilePath, string? section, bool hasOptions, string paramName)
+    {
+        // Arrange
+        var options = hasOptions ? new Mock<IOptionsMonitor<SampleOption>>().Object : null;
+        var constractor = () => new JsonWritableOptions<SampleOption>(jsonFilePath!, section!, options!);
+
+        // Act - Assert
+        _ = constractor.Should().ThrowExactly<ArgumentNullException>().WithParameterName(paramName);
+    }
+
     /// <summary>
     /// <see cref="JsonWritableOptions{TOptions}.Value"/> returns TOptions via <see cref="IOptionsMonitor{TOptions}"/>.
     /// </summary>
@@ -32,7 +46,7 @@ public sealed class JsonWritableOptionsTest
         var optionsMock = new Mock<IOptionsMonitor<SampleOption>>();
         _ = optionsMock.SetupGet(m => m.CurrentValue).Returns(sampleOption);
 
-        var sut = new JsonWritableOptions<SampleOption>(null!, "", optionsMock.Object, null);
+        var sut = new JsonWritableOptions<SampleOption>("", "", optionsMock.Object);
 
         // Act - Assert
         _ = sut.Value.Should().Be(sampleOption);
@@ -50,7 +64,7 @@ public sealed class JsonWritableOptionsTest
         var optionsMock = new Mock<IOptionsMonitor<SampleOption>>();
         _ = optionsMock.SetupGet(m => m.CurrentValue).Returns(sampleOption);
 
-        var sut = new JsonWritableOptions<SampleOption>(null!, "", optionsMock.Object, null);
+        var sut = new JsonWritableOptions<SampleOption>("", "", optionsMock.Object);
 
         // Act - Assert
         _ = sut.CurrentValue.Should().Be(sampleOption);
@@ -68,7 +82,7 @@ public sealed class JsonWritableOptionsTest
         var optionsMock = new Mock<IOptionsMonitor<SampleOption>>();
         _ = optionsMock.Setup(m => m.Get(It.IsAny<string>())).Returns(sampleOption);
 
-        var sut = new JsonWritableOptions<SampleOption>(null!, "", optionsMock.Object, null);
+        var sut = new JsonWritableOptions<SampleOption>("", "", optionsMock.Object);
 
         // Act - Assert
         _ = sut.Get("Foo").Should().Be(sampleOption);
@@ -91,7 +105,7 @@ public sealed class JsonWritableOptionsTest
         var action = (SampleOption option, string section)
             => Console.WriteLine($"{nameof(SampleOption)}:{section} changed to {option}");
 
-        var sut = new JsonWritableOptions<SampleOption>(null!, "", optionsMock.Object, null);
+        var sut = new JsonWritableOptions<SampleOption>("", "", optionsMock.Object);
 
         // Act
         _ = sut.OnChange(action);
@@ -114,9 +128,10 @@ public sealed class JsonWritableOptionsTest
         using var tempFile = new TempFileProvider();
         tempFile.AppendAllText(fileText);
 
+        var optionsStub = new Mock<IOptionsMonitor<SampleOption>>().Object;
         var configStub = new Mock<IConfigurationRoot>();
 
-        var sut = new JsonWritableOptions<SampleOption>(tempFile.Path, nameof(SampleOption), null!, configStub.Object);
+        var sut = new JsonWritableOptions<SampleOption>(tempFile.Path, nameof(SampleOption), optionsStub, configStub.Object);
 
         // Act
         sut.Update(new()
@@ -153,9 +168,10 @@ public sealed class JsonWritableOptionsTest
         using var tempFile = new TempFileProvider();
         tempFile.AppendAllText(fileText, Encoding.UTF8);
 
+        var optionsStub = new Mock<IOptionsMonitor<SampleOption>>().Object;
         var configStub = new Mock<IConfigurationRoot>();
 
-        var sut = new JsonWritableOptions<SampleOption>(tempFile.Path, nameof(SampleOption), null!, configStub.Object);
+        var sut = new JsonWritableOptions<SampleOption>(tempFile.Path, nameof(SampleOption), optionsStub, configStub.Object);
 
         // Act
         sut.Update(new()
@@ -192,7 +208,9 @@ public sealed class JsonWritableOptionsTest
         using var tempFile = new TempFileProvider();
         tempFile.AppendAllText(fileText);
 
-        var sut = new JsonWritableOptions<SampleOption>(tempFile.Path, nameof(SampleOption), null!);
+        var optionsStub = new Mock<IOptionsMonitor<SampleOption>>().Object;
+
+        var sut = new JsonWritableOptions<SampleOption>(tempFile.Path, nameof(SampleOption), optionsStub);
 
         // Act
         sut.Update(new()
@@ -217,9 +235,10 @@ public sealed class JsonWritableOptionsTest
         using var tempFile = new TempFileProvider();
         tempFile.AppendAllText("{}");
 
+        var optionsStub = new Mock<IOptionsMonitor<SampleOption>>().Object;
         var configStub = new Mock<IConfigurationRoot>();
 
-        var sut = new JsonWritableOptions<SampleOption>(tempFile.Path, nameof(SampleOption), null!, configStub.Object);
+        var sut = new JsonWritableOptions<SampleOption>(tempFile.Path, nameof(SampleOption), optionsStub, configStub.Object);
 
         // Act
         sut.Update(new()


### PR DESCRIPTION
## Changes
- Store `JsonEncodedText` instead of `string`
- Add `null` check on `JsonWritableOptions<TOptions>` constractor (BREAKING CHANGE)
  - Constractor throws `ArgumentNullException` now