### PR TITLE
ci: add job summaries on benchmark

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -37,3 +37,15 @@ jobs:
         with:
           name: BenchmarkResults
           path: sandbox/Benchmark/BenchmarkDotNet.Artifacts/
+
+      - name: Add Job Summaries
+        shell: pwsh
+        run: |
+          "# Benchmark Result:bar_chart:" >> $GITHUB_STEP_SUMMARY
+          Get-Content -Path ./sandbox/Benchmark/BenchmarkDotNet.Artifacts/results/Benchmark.WritableOptionsBenchmark-report-github.md >> $GITHUB_STEP_SUMMARY
+          "## Legends" >> $GITHUB_STEP_SUMMARY
+          "- **Mean**: Arithmetic mean of all measurements" >> $GITHUB_STEP_SUMMARY
+          "- **Error**: Half of 99.9% confidence interval" >> $GITHUB_STEP_SUMMARY
+          "- **StdDev**: Standard deviation of all measurements" >> $GITHUB_STEP_SUMMARY
+          "- **Ratio**: Mean of the ratio distribution ([Current]/[Baseline])" >> $GITHUB_STEP_SUMMARY
+          "- **1 ms**: 1 Millisecond (0.001 sec)" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
https://github.blog/2022-05-09-supercharging-github-actions-with-job-summaries/