### PR TITLE
perf: extract `JsonWriterOptions` into a variable

### DIFF
--- a/src/Nogic.WritableOptions/JsonWritableOptions.cs
+++ b/src/Nogic.WritableOptions/JsonWritableOptions.cs
@@ -29,6 +29,12 @@ public class JsonWritableOptions<TOptions> : IWritableOptions<TOptions> where TO
     /// </summary>
     private readonly IConfigurationRoot? _configuration;
 
+    private readonly JsonWriterOptions _jsonWriterOptions = new()
+    {
+        Indented = true,
+        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
+    };
+
     /// <summary>
     /// Initializes a new instance of the JsonWritableOptions class.
     /// </summary>
@@ -108,12 +114,8 @@ public class JsonWritableOptions<TOptions> : IWritableOptions<TOptions> where TO
                 stream.Write(utf8bom.ToArray(), 0, utf8bom.Length);
 #endif
             }
-
-            var writer = new Utf8JsonWriter(stream, new()
-            {
-                Indented = true,
-                Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
-            });
+            
+            var writer = new Utf8JsonWriter(stream, _jsonWriterOptions);
 
             writer.WriteStartObject();
             bool isWritten = false;

--- a/src/Nogic.WritableOptions/JsonWritableOptions.cs
+++ b/src/Nogic.WritableOptions/JsonWritableOptions.cs
@@ -114,7 +114,7 @@ public class JsonWritableOptions<TOptions> : IWritableOptions<TOptions> where TO
                 stream.Write(utf8bom.ToArray(), 0, utf8bom.Length);
 #endif
             }
-            
+
             var writer = new Utf8JsonWriter(stream, _jsonWriterOptions);
 
             writer.WriteStartObject();


### PR DESCRIPTION
The `JsonWriterOptions` is extracted so it won't be allocated and garbage collected on every call.