### PR TITLE
refactor: optimize JsonWritableOptions.Update

### DIFF
--- a/sandbox/Benchmark/WritableOptionsBenchmark.cs
+++ b/sandbox/Benchmark/WritableOptionsBenchmark.cs
@@ -33,7 +33,7 @@ public class WritableOptionsBenchmark
     public void GlobalSetup() => _option = new()
     {
         LastLaunchedAt = DateTime.Now,
-        StringSettings = Enumerable.Range(1, 100).Select((_) => Guid.NewGuid().ToString()).ToArray(),
+        StringSettings = Enumerable.Range(1, 100).Select(static (_) => Guid.NewGuid().ToString()).ToArray(),
         IntSettings = Enumerable.Range(1, 100).ToArray()
     };
 

--- a/sandbox/ConsoleAppExample/Program.cs
+++ b/sandbox/ConsoleAppExample/Program.cs
@@ -4,7 +4,7 @@ using Nogic.WritableOptions;
 const string ApplicationName = "ConsoleAppExample";
 
 var builder = ConsoleApp.CreateBuilder(args);
-builder.ConfigureServices((ctx, services) =>
+builder.ConfigureServices(static (ctx, services) =>
 {
     // Load app settings
     var config = ctx.Configuration;

--- a/src/Nogic.WritableOptions/JsonWritableOptions.cs
+++ b/src/Nogic.WritableOptions/JsonWritableOptions.cs
@@ -113,18 +113,14 @@ public class JsonWritableOptions<TOptions> : IWritableOptions<TOptions> where TO
                     stream.Position = 0;
                 }
 
-                // Load fake JSON to avoid Utf8JsonReader error
-                if (utf8Json.Length == 0)
-                    utf8Json = "{}"u8;
-
-                var reader = new Utf8JsonReader(utf8Json);
-                using var jsonDocument = JsonDocument.ParseValue(ref reader);
+                var reader = new Utf8JsonReader(utf8Json.Length > 0 ? utf8Json : "{}"u8);
+                var currentJson = JsonElement.ParseValue(ref reader);
                 var writer = new Utf8JsonWriter(stream, _jsonWriterOptions);
 
                 writer.WriteStartObject(); // {
                 bool isWritten = false;
-                var serializedOptionsValue = JsonSerializer.SerializeToDocument(changedValue);
-                foreach (var element in jsonDocument.RootElement.EnumerateObject())
+                var serializedOptionsValue = JsonSerializer.SerializeToElement(changedValue);
+                foreach (var element in currentJson.EnumerateObject())
                 {
                     if (!element.NameEquals(_section.EncodedUtf8Bytes))
                     {

--- a/src/Nogic.WritableOptions/JsonWritableOptions.cs
+++ b/src/Nogic.WritableOptions/JsonWritableOptions.cs
@@ -30,7 +30,7 @@ public class JsonWritableOptions<TOptions> : IWritableOptions<TOptions> where TO
     /// </summary>
     private readonly IConfiguration? _configuration;
 
-    private readonly JsonWriterOptions _jsonWriterOptions = new()
+    private static readonly JsonWriterOptions _jsonWriterOptions = new()
     {
         Indented = true,
         Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping

--- a/src/Nogic.WritableOptions/JsonWritableOptions.cs
+++ b/src/Nogic.WritableOptions/JsonWritableOptions.cs
@@ -117,7 +117,7 @@ public class JsonWritableOptions<TOptions> : IWritableOptions<TOptions> where TO
 
             writer.WriteStartObject(); // {
             bool isWritten = false;
-            var optionsElement = JsonDocument.Parse(JsonSerializer.SerializeToUtf8Bytes(changedValue));
+            var serializedOptionsValue = JsonSerializer.SerializeToDocument(changedValue);
             foreach (var element in jsonDocument.RootElement.EnumerateObject())
             {
                 if (!element.NameEquals(_section.EncodedUtf8Bytes))
@@ -126,13 +126,13 @@ public class JsonWritableOptions<TOptions> : IWritableOptions<TOptions> where TO
                     continue;
                 }
                 writer.WritePropertyName(_section);
-                optionsElement.WriteTo(writer);
+                serializedOptionsValue.WriteTo(writer);
                 isWritten = true;
             }
             if (!isWritten)
             {
                 writer.WritePropertyName(_section);
-                optionsElement.WriteTo(writer);
+                serializedOptionsValue.WriteTo(writer);
             }
             writer.WriteEndObject(); // }
 

--- a/test/Nogic.WritableOptions.Tests/JsonWritableOptions.Test.cs
+++ b/test/Nogic.WritableOptions.Tests/JsonWritableOptions.Test.cs
@@ -57,13 +57,13 @@ public sealed class JsonWritableOptionsTest
         // Arrange
         var sampleOption = GenerateOption();
         var optionsMock = new Mock<IOptionsMonitor<SampleOption>>();
-        _ = optionsMock.SetupGet(m => m.CurrentValue).Returns(sampleOption);
+        _ = optionsMock.SetupGet(static m => m.CurrentValue).Returns(sampleOption);
 
         var sut = new JsonWritableOptions<SampleOption>("", "", optionsMock.Object);
 
         // Act - Assert
         _ = sut.Value.Should().Be(sampleOption);
-        optionsMock.VerifyGet(m => m.CurrentValue, Times.Once());
+        optionsMock.VerifyGet(static m => m.CurrentValue, Times.Once());
     }
 
     /// <summary>
@@ -75,13 +75,13 @@ public sealed class JsonWritableOptionsTest
         // Arrange
         var sampleOption = GenerateOption();
         var optionsMock = new Mock<IOptionsMonitor<SampleOption>>();
-        _ = optionsMock.SetupGet(m => m.CurrentValue).Returns(sampleOption);
+        _ = optionsMock.SetupGet(static m => m.CurrentValue).Returns(sampleOption);
 
         var sut = new JsonWritableOptions<SampleOption>("", "", optionsMock.Object);
 
         // Act - Assert
         _ = sut.CurrentValue.Should().Be(sampleOption);
-        optionsMock.VerifyGet(m => m.CurrentValue, Times.Once());
+        optionsMock.VerifyGet(static m => m.CurrentValue, Times.Once());
     }
 
     /// <summary>
@@ -93,7 +93,7 @@ public sealed class JsonWritableOptionsTest
         // Arrange
         var sampleOption = GenerateOption();
         var optionsMock = new Mock<IOptionsMonitor<SampleOption>>();
-        _ = optionsMock.Setup(m => m.Get(It.IsAny<string>())).Returns(sampleOption);
+        _ = optionsMock.Setup(static m => m.Get(It.IsAny<string>())).Returns(sampleOption);
 
         var sut = new JsonWritableOptions<SampleOption>("", "", optionsMock.Object);
 
@@ -101,9 +101,9 @@ public sealed class JsonWritableOptionsTest
         _ = sut.Get("Foo").Should().Be(sampleOption);
         _ = sut.Get("Bar").Should().Be(sampleOption);
 
-        optionsMock.Verify(m => m.Get(It.IsAny<string>()), Times.Exactly(2));
-        optionsMock.Verify(m => m.Get("Foo"), Times.Once());
-        optionsMock.Verify(m => m.Get("Bar"), Times.Once());
+        optionsMock.Verify(static m => m.Get(It.IsAny<string>()), Times.Exactly(2));
+        optionsMock.Verify(static m => m.Get("Foo"), Times.Once());
+        optionsMock.Verify(static m => m.Get("Bar"), Times.Once());
     }
 
     /// <summary>
@@ -115,7 +115,7 @@ public sealed class JsonWritableOptionsTest
         // Arrange
         var sampleOption = GenerateOption();
         var optionsMock = new Mock<IOptionsMonitor<SampleOption>>();
-        var action = (SampleOption option, string? section)
+        var action = static (SampleOption option, string? section)
             => Console.WriteLine($"{nameof(SampleOption)}:{section} changed to {option}");
 
         var sut = new JsonWritableOptions<SampleOption>("", "", optionsMock.Object);
@@ -179,7 +179,7 @@ public sealed class JsonWritableOptionsTest
         }
         """;
         _ = tempFile.ReadAllText().Should().Be(NormalizeEndLine(expectedJson));
-        configStub.Verify(m => m.Reload(), Times.Never());
+        configStub.Verify(static m => m.Reload(), Times.Never());
     }
 
     /// <summary>
@@ -234,7 +234,7 @@ public sealed class JsonWritableOptionsTest
         }
         """;
         _ = tempFile.ReadAllText(Encoding.UTF8).Should().Be(NormalizeEndLine(expectedJson));
-        configStub.Verify(m => m.Reload(), Times.Never());
+        configStub.Verify(static m => m.Reload(), Times.Never());
     }
 
     /// <summary>
@@ -318,7 +318,7 @@ public sealed class JsonWritableOptionsTest
         }
         """;
         _ = tempFile.ReadAllText().Should().Be(NormalizeEndLine(expectedJson));
-        configStub.Verify(m => m.Reload(), Times.Once());
+        configStub.Verify(static m => m.Reload(), Times.Once());
     }
 
     /// <summary>


### PR DESCRIPTION
It takes 11~17% faster than v3.0.0
## Changes
- use `JsonElement` struct instead of `JsonDocument` class
- use `ArrayPool` to cache utf8 byte data
- use single `FileStream` on read/write JSON
- use [static lammda](https://learn.microsoft.com/dotnet/csharp/language-reference/operators/lambda-expressions#capture-of-outer-variables-and-variable-scope-in-lambda-expressions) on test & sample projects