### PR TITLE
refactor: use Encoding.Preamble to reduce array creation

### DIFF
--- a/src/Nogic.WritableOptions/JsonWritableOptions.cs
+++ b/src/Nogic.WritableOptions/JsonWritableOptions.cs
@@ -100,7 +100,11 @@ public class JsonWritableOptions<TOptions> : IWritableOptions<TOptions> where TO
                 ReadOnlySpan<byte> utf8Json = buffer.AsSpan();
 
                 // Check BOM
+#if NETCOREAPP2_1_OR_GREATER
+                var utf8bom = Encoding.UTF8.Preamble;
+#else
                 ReadOnlySpan<byte> utf8bom = Encoding.UTF8.GetPreamble();
+#endif
                 if (utf8Json.StartsWith(utf8bom))
                 {
 #pragma warning disable IDE0057


### PR DESCRIPTION
[`Encoding.Preamble`](https://learn.microsoft.com/dotnet/api/system.text.encoding.preamble) returns `ReadOnlySpan<byte>`, so it reduces heap allocations than [`Encoding.GetPreamble()`](https://learn.microsoft.com/dotnet/api/system.text.encoding.getpreamble).

only on .NET Core 2.1 or higher

## Allocations
- .NET 6: 32.91 MB(#182) -> 32.88 MB
- .NET 7: 32.91 MB(#182) -> 32.88 MB