### PR TITLE
Implement JsonSerializerOptions as a nullable Func parameter

### DIFF
--- a/src/Nogic.WritableOptions/JsonWritableOptions.cs
+++ b/src/Nogic.WritableOptions/JsonWritableOptions.cs
@@ -2,6 +2,7 @@ using System.Buffers;
 using System.Text;
 using System.Text.Encodings.Web;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Options;
 
@@ -14,21 +15,31 @@ namespace Nogic.WritableOptions;
 public class JsonWritableOptions<TOptions> : IWritableOptions<TOptions> where TOptions : class, new()
 {
     /// <summary>
-    /// <inheritdoc cref="JsonWritableOptions(string, string, IOptionsMonitor{TOptions}, IConfiguration?)" path="/param[@name='jsonFilePath']"/>
+    /// <inheritdoc cref="JsonWritableOptions(string, string, IOptionsMonitor{TOptions}, IConfiguration?, Func<JsonSerializerOptions>?)" path="/param[@name='jsonFilePath']"/>
     /// </summary>
     private readonly string _jsonFilePath;
     /// <summary>
-    /// <inheritdoc cref="JsonWritableOptions(string, string, IOptionsMonitor{TOptions}, IConfiguration?)" path="/param[@name='section']"/>
+    /// <inheritdoc cref="JsonWritableOptions(string, string, IOptionsMonitor{TOptions}, IConfiguration?, Func<JsonSerializerOptions>?)" path="/param[@name='section']"/>
     /// </summary>
     private readonly JsonEncodedText _section;
     /// <summary>
-    /// <inheritdoc cref="JsonWritableOptions(string, string, IOptionsMonitor{TOptions}, IConfiguration?)" path="/param[@name='options']"/>
+    /// <inheritdoc cref="JsonWritableOptions(string, string, IOptionsMonitor{TOptions}, IConfiguration?, Func<JsonSerializerOptions>?)" path="/param[@name='options']"/>
     /// </summary>
     private readonly IOptionsMonitor<TOptions> _options;
     /// <summary>
-    /// <inheritdoc cref="JsonWritableOptions(string, string, IOptionsMonitor{TOptions}, IConfiguration?)" path="/param[@name='configuration']"/>
+    /// <inheritdoc cref="JsonWritableOptions(string, string, IOptionsMonitor{TOptions}, IConfiguration?, Func<JsonSerializerOptions>?)" path="/param[@name='configuration']"/>
     /// </summary>
     private readonly IConfiguration? _configuration;
+    /// <summary>
+    /// <inheritdoc cref="JsonWritableOptions(string, string, IOptionsMonitor{TOptions}, IConfiguration?, Func<JsonSerializerOptions>?)" path="/param[@name='serializerOptions']"/>
+    /// </summary>
+    private readonly JsonSerializerOptions _serializerOptions;
+
+    private static readonly JsonSerializerOptions _defaultJsonSerializerOptions = new()
+    {
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        Converters = { new JsonStringEnumConverter() }
+    };
 
     private static readonly JsonWriterOptions _jsonWriterOptions = new()
     {
@@ -46,7 +57,7 @@ public class JsonWritableOptions<TOptions> : IWritableOptions<TOptions> where TO
     /// <exception cref="ArgumentNullException">
     /// Throws if <paramref name="jsonFilePath"/>, <paramref name="section"/> or <paramref name="options"/> is <see langword="null"/>.
     /// </exception>
-    public JsonWritableOptions(string jsonFilePath, string section, IOptionsMonitor<TOptions> options, IConfiguration? configuration = null)
+    public JsonWritableOptions(string jsonFilePath, string section, IOptionsMonitor<TOptions> options, IConfiguration? configuration = null, Func<JsonSerializerOptions>? serializerOptions = null)
     {
 #if NET6_0_OR_GREATER
         ArgumentNullException.ThrowIfNull(jsonFilePath);
@@ -62,6 +73,7 @@ public class JsonWritableOptions<TOptions> : IWritableOptions<TOptions> where TO
         _section = JsonEncodedText.Encode(section);
         _options = options;
         _configuration = configuration;
+        _serializerOptions = serializerOptions == null ? _defaultJsonSerializerOptions : serializerOptions();
 #if !NET6_0_OR_GREATER
         // Port of ArgumentNullException.ThrowIfNull
         static void ThrowIfNull(object? argument, string paramName)
@@ -123,7 +135,7 @@ public class JsonWritableOptions<TOptions> : IWritableOptions<TOptions> where TO
 
                 writer.WriteStartObject(); // {
                 bool isWritten = false;
-                var serializedOptionsValue = JsonSerializer.SerializeToElement(changedValue);
+                var serializedOptionsValue = JsonSerializer.SerializeToElement(changedValue, _serializerOptions);
                 foreach (var element in currentJson.EnumerateObject())
                 {
                     if (!element.NameEquals(_section.EncodedUtf8Bytes))

--- a/src/Nogic.WritableOptions/JsonWritableOptions.cs
+++ b/src/Nogic.WritableOptions/JsonWritableOptions.cs
@@ -2,7 +2,6 @@ using System.Buffers;
 using System.Text;
 using System.Text.Encodings.Web;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Options;
 
@@ -15,31 +14,25 @@ namespace Nogic.WritableOptions;
 public class JsonWritableOptions<TOptions> : IWritableOptions<TOptions> where TOptions : class, new()
 {
     /// <summary>
-    /// <inheritdoc cref="JsonWritableOptions(string, string, IOptionsMonitor{TOptions}, IConfiguration?, Func<JsonSerializerOptions>?)" path="/param[@name='jsonFilePath']"/>
+    /// <inheritdoc cref="JsonWritableOptions(string, string, IOptionsMonitor{TOptions}, IConfiguration?)" path="/param[@name='jsonFilePath']"/>
     /// </summary>
     private readonly string _jsonFilePath;
     /// <summary>
-    /// <inheritdoc cref="JsonWritableOptions(string, string, IOptionsMonitor{TOptions}, IConfiguration?, Func<JsonSerializerOptions>?)" path="/param[@name='section']"/>
+    /// <inheritdoc cref="JsonWritableOptions(string, string, IOptionsMonitor{TOptions}, IConfiguration?)" path="/param[@name='section']"/>
     /// </summary>
     private readonly JsonEncodedText _section;
     /// <summary>
-    /// <inheritdoc cref="JsonWritableOptions(string, string, IOptionsMonitor{TOptions}, IConfiguration?, Func<JsonSerializerOptions>?)" path="/param[@name='options']"/>
+    /// <inheritdoc cref="JsonWritableOptions(string, string, IOptionsMonitor{TOptions}, IConfiguration?)" path="/param[@name='options']"/>
     /// </summary>
     private readonly IOptionsMonitor<TOptions> _options;
     /// <summary>
-    /// <inheritdoc cref="JsonWritableOptions(string, string, IOptionsMonitor{TOptions}, IConfiguration?, Func<JsonSerializerOptions>?)" path="/param[@name='configuration']"/>
+    /// <inheritdoc cref="JsonWritableOptions(string, string, IOptionsMonitor{TOptions}, IConfiguration?)" path="/param[@name='configuration']"/>
     /// </summary>
     private readonly IConfiguration? _configuration;
     /// <summary>
-    /// <inheritdoc cref="JsonWritableOptions(string, string, IOptionsMonitor{TOptions}, IConfiguration?, Func<JsonSerializerOptions>?)" path="/param[@name='serializerOptions']"/>
+    /// <inheritdoc cref="JsonWritableOptions(string, string, IOptionsMonitor{TOptions}, JsonSerializerOptions, IConfiguration?)" path="/param[@name='serializerOptions']"/>
     /// </summary>
-    private readonly JsonSerializerOptions _serializerOptions;
-
-    private static readonly JsonSerializerOptions _defaultJsonSerializerOptions = new()
-    {
-        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
-        Converters = { new JsonStringEnumConverter() }
-    };
+    private readonly JsonSerializerOptions? _serializerOptions;
 
     private static readonly JsonWriterOptions _jsonWriterOptions = new()
     {
@@ -63,7 +56,7 @@ public class JsonWritableOptions<TOptions> : IWritableOptions<TOptions> where TO
     /// <exception cref="ArgumentNullException">
     /// Throws if <paramref name="jsonFilePath"/>, <paramref name="section"/> or <paramref name="options"/> is <see langword="null"/>.
     /// </exception>
-    public JsonWritableOptions(string jsonFilePath, string section, IOptionsMonitor<TOptions> options, IConfiguration? configuration = null, Func<JsonSerializerOptions>? serializerOptions = null)
+    public JsonWritableOptions(string jsonFilePath, string section, IOptionsMonitor<TOptions> options, IConfiguration? configuration = null)
     {
 #if NET6_0_OR_GREATER
         ArgumentNullException.ThrowIfNull(jsonFilePath);
@@ -79,7 +72,6 @@ public class JsonWritableOptions<TOptions> : IWritableOptions<TOptions> where TO
         _section = JsonEncodedText.Encode(section);
         _options = options;
         _configuration = configuration;
-        _serializerOptions = serializerOptions == null ? _defaultJsonSerializerOptions : serializerOptions();
 #if !NET6_0_OR_GREATER
         // Port of ArgumentNullException.ThrowIfNull
         static void ThrowIfNull(object? argument, string paramName)
@@ -89,6 +81,11 @@ public class JsonWritableOptions<TOptions> : IWritableOptions<TOptions> where TO
         }
 #endif
     }
+
+    /// <inheritdoc cref="JsonWritableOptions(string, string, IOptionsMonitor{TOptions}, IConfiguration?)"/>
+    /// <param name="serializerOptions">Serializer options for write JSON</param>
+    public JsonWritableOptions(string jsonFilePath, string section, IOptionsMonitor<TOptions> options, JsonSerializerOptions serializerOptions, IConfiguration? configuration = null)
+        : this(jsonFilePath, section, options, configuration) => _serializerOptions = serializerOptions;
 
     /// <inheritdoc/>
     public TOptions Value => _options.CurrentValue;

--- a/test/Nogic.WritableOptions.Tests/ServiceCollectionExtension.Test.cs
+++ b/test/Nogic.WritableOptions.Tests/ServiceCollectionExtension.Test.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -10,7 +11,7 @@ namespace Nogic.WritableOptions.Tests;
 public sealed class ServiceCollectionExtensionTest
 {
     /// <summary>
-    /// <see cref="ServiceCollectionExtension.ConfigureWritable{TOptions}"/> calls <see cref="ServiceCollectionServiceExtensions.AddTransient{IWritableOptions{TOptions}}(IServiceCollection, Func{IServiceProvider, IWritableOptions{TOptions}})"/>.
+    /// <see cref="ServiceCollectionExtension.ConfigureWritable{TOptions}(IServiceCollection, IConfigurationSection, string)"/> calls <see cref="ServiceCollectionServiceExtensions.AddTransient{IWritableOptions{TOptions}}(IServiceCollection, Func{IServiceProvider, IWritableOptions{TOptions}})"/>.
     /// </summary>
     [TestMethod($"{nameof(ServiceCollectionExtension.ConfigureWritable)}<TOptions>() calls {nameof(ServiceCollectionServiceExtensions.AddTransient)}<IWritableOptions<TOptions>>().")]
     public void ConfigureWritable_Calls_AddTransient()
@@ -35,7 +36,58 @@ public sealed class ServiceCollectionExtensionTest
     }
 
     /// <summary>
-    /// <see cref="ServiceCollectionExtension.ConfigureWritableWithExplicitPath{TOptions}"/> calls <see cref="ServiceCollectionServiceExtensions.AddTransient{IWritableOptions{TOptions}}(IServiceCollection, Func{IServiceProvider, IWritableOptions{TOptions}})"/>.
+    /// <see cref="ServiceCollectionExtension.ConfigureWritable{TOptions}(IServiceCollection, IConfigurationSection, JsonSerializerOptions, string)"/> calls <see cref="ServiceCollectionServiceExtensions.AddTransient{IWritableOptions{TOptions}}(IServiceCollection, Func{IServiceProvider, IWritableOptions{TOptions}})"/>.
+    /// </summary>
+    [TestMethod($"{nameof(ServiceCollectionExtension.ConfigureWritable)}<TOptions>({nameof(JsonSerializerOptions)}) calls {nameof(ServiceCollectionServiceExtensions.AddTransient)}<IWritableOptions<TOptions>>().")]
+    public void ConfigureWritable_JsonSerializerOptions_Calls_AddTransient()
+    {
+        // Arrange
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection()
+            .Build();
+        var service = new ServiceCollection();
+        var options = new JsonSerializerOptions();
+
+        // Act
+        _ = service.ConfigureWritable<SampleOption>(configuration.GetSection("Nested"), options);
+        var provider = service.BuildServiceProvider();
+
+        // Assert
+        var option = provider.GetService<IWritableOptions<SampleOption>>();
+        var otherOption = provider.GetService<IWritableOptions<SampleOption>>();
+
+        _ = option.Should().NotBeNull()
+            .And.BeOfType<JsonWritableOptions<SampleOption>>()
+            .And.NotBe(otherOption);
+    }
+
+    /// <summary>
+    /// <see cref="ServiceCollectionExtension.ConfigureWritable{TOptions}(IServiceCollection, IConfigurationSection, Func{JsonSerializerOptions}, string)"/> calls <see cref="ServiceCollectionServiceExtensions.AddTransient{IWritableOptions{TOptions}}(IServiceCollection, Func{IServiceProvider, IWritableOptions{TOptions}})"/>.
+    /// </summary>
+    [TestMethod($"{nameof(ServiceCollectionExtension.ConfigureWritable)}<TOptions>({nameof(Func<JsonSerializerOptions>)}) calls {nameof(ServiceCollectionServiceExtensions.AddTransient)}<IWritableOptions<TOptions>>().")]
+    public void ConfigureWritable_FuncJsonSerializerOptions_Calls_AddTransient()
+    {
+        // Arrange
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection()
+            .Build();
+        var service = new ServiceCollection();
+
+        // Act
+        _ = service.ConfigureWritable<SampleOption>(configuration.GetSection("Nested"), () => new());
+        var provider = service.BuildServiceProvider();
+
+        // Assert
+        var option = provider.GetService<IWritableOptions<SampleOption>>();
+        var otherOption = provider.GetService<IWritableOptions<SampleOption>>();
+
+        _ = option.Should().NotBeNull()
+            .And.BeOfType<JsonWritableOptions<SampleOption>>()
+            .And.NotBe(otherOption);
+    }
+
+    /// <summary>
+    /// <see cref="ServiceCollectionExtension.ConfigureWritableWithExplicitPath{TOptions}(IServiceCollection, IConfigurationSection, string, string)"/> calls <see cref="ServiceCollectionServiceExtensions.AddTransient{IWritableOptions{TOptions}}(IServiceCollection, Func{IServiceProvider, IWritableOptions{TOptions}})"/>.
     /// </summary>
     [TestMethod($"{nameof(ServiceCollectionExtension.ConfigureWritableWithExplicitPath)}<TOptions>() calls {nameof(ServiceCollectionServiceExtensions.AddTransient)}<IWritableOptions<TOptions>>().")]
     public void ConfigureWritableWithExplicitPath_Calls_AddTransient()
@@ -48,6 +100,57 @@ public sealed class ServiceCollectionExtensionTest
 
         // Act
         _ = service.ConfigureWritableWithExplicitPath<SampleOption>(configuration.GetSection("Nested"), AppDomain.CurrentDomain.BaseDirectory!);
+        var provider = service.BuildServiceProvider();
+
+        // Assert
+        var option = provider.GetService<IWritableOptions<SampleOption>>();
+        var otherOption = provider.GetService<IWritableOptions<SampleOption>>();
+
+        _ = option.Should().NotBeNull()
+            .And.BeOfType<JsonWritableOptions<SampleOption>>()
+            .And.NotBe(otherOption);
+    }
+
+    /// <summary>
+    /// <see cref="ServiceCollectionExtension.ConfigureWritableWithExplicitPath{TOptions}(IServiceCollection, IConfigurationSection, string, JsonSerializerOptions, string)"/> calls <see cref="ServiceCollectionServiceExtensions.AddTransient{IWritableOptions{TOptions}}(IServiceCollection, Func{IServiceProvider, IWritableOptions{TOptions}})"/>.
+    /// </summary>
+    [TestMethod($"{nameof(ServiceCollectionExtension.ConfigureWritableWithExplicitPath)}<TOptions>({nameof(JsonSerializerOptions)}) calls {nameof(ServiceCollectionServiceExtensions.AddTransient)}<IWritableOptions<TOptions>>().")]
+    public void ConfigureWritableWithExplicitPath_JsonSerializerOptions_Calls_AddTransient()
+    {
+        // Arrange
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection()
+            .Build();
+        var service = new ServiceCollection();
+        var options = new JsonSerializerOptions();
+
+        // Act
+        _ = service.ConfigureWritableWithExplicitPath<SampleOption>(configuration.GetSection("Nested"), AppDomain.CurrentDomain.BaseDirectory!, options);
+        var provider = service.BuildServiceProvider();
+
+        // Assert
+        var option = provider.GetService<IWritableOptions<SampleOption>>();
+        var otherOption = provider.GetService<IWritableOptions<SampleOption>>();
+
+        _ = option.Should().NotBeNull()
+            .And.BeOfType<JsonWritableOptions<SampleOption>>()
+            .And.NotBe(otherOption);
+    }
+
+    /// <summary>
+    /// <see cref="ServiceCollectionExtension.ConfigureWritableWithExplicitPath{TOptions}(IServiceCollection, IConfigurationSection, string, Func{JsonSerializerOptions}, string)"/> calls <see cref="ServiceCollectionServiceExtensions.AddTransient{IWritableOptions{TOptions}}(IServiceCollection, Func{IServiceProvider, IWritableOptions{TOptions}})"/>.
+    /// </summary>
+    [TestMethod($"{nameof(ServiceCollectionExtension.ConfigureWritableWithExplicitPath)}<TOptions>({nameof(Func<JsonSerializerOptions>)}) calls {nameof(ServiceCollectionServiceExtensions.AddTransient)}<IWritableOptions<TOptions>>().")]
+    public void ConfigureWritableWithExplicitPath_FuncJsonSerializerOptions_Calls_AddTransient()
+    {
+        // Arrange
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection()
+            .Build();
+        var service = new ServiceCollection();
+
+        // Act
+        _ = service.ConfigureWritableWithExplicitPath<SampleOption>(configuration.GetSection("Nested"), AppDomain.CurrentDomain.BaseDirectory!, () => new());
         var provider = service.BuildServiceProvider();
 
         // Assert


### PR DESCRIPTION
Enhancement for #310 (and my also be a resolution for #308)

I've spent some time and added tests covering using the new default JsonSerialiserOptions and passing in a default JsonSerialiserOptions as the new optional Func parameter