### PR TITLE
fix: support update JSON that uses comment or trailing comma

### DIFF
--- a/src/Nogic.WritableOptions/JsonWritableOptions.cs
+++ b/src/Nogic.WritableOptions/JsonWritableOptions.cs
@@ -33,7 +33,13 @@ public class JsonWritableOptions<TOptions> : IWritableOptions<TOptions> where TO
     private static readonly JsonWriterOptions _jsonWriterOptions = new()
     {
         Indented = true,
-        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
+        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+    };
+
+    private static readonly JsonReaderOptions _jsonReaderOptions = new()
+    {
+        CommentHandling = JsonCommentHandling.Skip,
+        AllowTrailingCommas = true,
     };
 
     /// <summary>
@@ -117,7 +123,7 @@ public class JsonWritableOptions<TOptions> : IWritableOptions<TOptions> where TO
                     stream.Position = 0;
                 }
 
-                var reader = new Utf8JsonReader(utf8Json.Length > 0 ? utf8Json : "{}"u8);
+                var reader = new Utf8JsonReader(utf8Json.Length > 0 ? utf8Json : "{}"u8, _jsonReaderOptions);
                 var currentJson = JsonElement.ParseValue(ref reader);
                 var writer = new Utf8JsonWriter(stream, _jsonWriterOptions);
 

--- a/test/Nogic.WritableOptions.Tests/JsonWritableOptions.Test.cs
+++ b/test/Nogic.WritableOptions.Tests/JsonWritableOptions.Test.cs
@@ -166,6 +166,30 @@ public sealed class JsonWritableOptionsTest
       }
     }
     """;
+    // lang=json,strict
+    private const string HasCommentJson = $$"""
+    {
+      // Line Comment
+      "{{nameof(SampleOption)}}": {
+          /*
+            Block Comment
+           */
+          "{{nameof(SampleOption.LastLaunchedAt)}}": "2020-10-01T00:00:00",
+          "{{nameof(SampleOption.Interval)}}": 1000,
+          "{{nameof(SampleOption.ConnectionString)}}": "bar"
+      }
+    }
+    """;
+    // lang=json,strict
+    private const string TrailingCommaJson = $$"""
+    {
+      "{{nameof(SampleOption)}}": {
+          "{{nameof(SampleOption.LastLaunchedAt)}}": "2020-10-01T00:00:00",
+          "{{nameof(SampleOption.Interval)}}": 1000,
+          "{{nameof(SampleOption.ConnectionString)}}": "bar",
+      },
+    }
+    """;
 
     /// <summary>
     /// <see cref="JsonWritableOptions{TOptions}.Update"/> writes expected JSON.
@@ -175,6 +199,8 @@ public sealed class JsonWritableOptionsTest
     [DataRow(EmptyJson, DisplayName = ".Update(TOptions) writes expected JSON")]
     [DataRow(ClassEmptyJson, DisplayName = ".Update(TOptions) writes expected JSON")]
     [DataRow(HasConfigJson, DisplayName = ".Update(TOptions) writes expected JSON")]
+    [DataRow(HasCommentJson, DisplayName = ".Update(TOptions) writes expected JSON")]
+    [DataRow(TrailingCommaJson, DisplayName = ".Update(TOptions) writes expected JSON")]
     public void Update_Writes_Json(string fileText)
     {
         // Arrange
@@ -202,6 +228,8 @@ public sealed class JsonWritableOptionsTest
     [DataRow(EmptyJson, DisplayName = ".Update(TOptions) writes expected JSON with BOM")]
     [DataRow(ClassEmptyJson, DisplayName = ".Update(TOptions) writes expected JSON with BOM")]
     [DataRow(HasConfigJson, DisplayName = ".Update(TOptions) writes expected JSON with BOM")]
+    [DataRow(HasCommentJson, DisplayName = ".Update(TOptions) writes expected JSON with BOM")]
+    [DataRow(TrailingCommaJson, DisplayName = ".Update(TOptions) writes expected JSON")]
     public void Update_Writes_Json_WithBOM(string fileText)
     {
         // Arrange
@@ -217,18 +245,7 @@ public sealed class JsonWritableOptionsTest
         sut.Update(_updatedOption);
 
         // Assert
-        /*lang=json,strict*/
-        const string expectedJson =
-        $$"""
-        {
-          "{{nameof(SampleOption)}}": {
-            "{{nameof(SampleOption.LastLaunchedAt)}}": "2020-12-01T00:00:00",
-            "{{nameof(SampleOption.Interval)}}": 5000,
-            "{{nameof(SampleOption.ConnectionString)}}": "foo"
-          }
-        }
-        """;
-        _ = tempFile.ReadAllText(Encoding.UTF8).Should().Be(NormalizeEndLine(expectedJson));
+        _ = tempFile.ReadAllText(Encoding.UTF8).Should().Be(NormalizeEndLine(ExpectedJson));
         configStub.Verify(static m => m.Reload(), Times.Never());
     }
 


### PR DESCRIPTION
ref #308

## Known Issue

`JsonWritableOptions.Update()` removes **ALL comments and trailing comma**.

### Source `appsettings.json`
```jsonc
{
  // Line Comment
  "SampleOption": {
      /*
        Block Comment
       */
      "LastLaunchedAt": "2020-10-01T00:00:00",
      "Interval": 1000,
      "ConnectionString": "foo",
  },
}
```

### Expected

```jsonc
{
  // Line Comment
  "SampleOption": {
      "LastLaunchedAt": "2024-06-01T00:00:00",
      "Interval": 5000,
      "ConnectionString": "bar"
  },
}
```

### Actual

```jsonc
{
  "SampleOption": {
      "LastLaunchedAt": "2024-06-01T00:00:00",
      "Interval": 5000,
      "ConnectionString": "bar"
  }
}
```