### PR TITLE
ci(gh-action): exclude .NET 6.0 job on M1 Mac

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -35,11 +35,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-13, macos-latest]
         framework: [net6.0, net8.0]
         include:
           - os: windows-latest
             framework: net48
+        exclude:
+          - os: macos-latest
+            framework: net6.0
     name: Debug Build & Test
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
This PR fixes the issue blocking the release of #311